### PR TITLE
fix: GitHub Actions permissions for tag creation

### DIFF
--- a/.github/workflows/version-management.yml
+++ b/.github/workflows/version-management.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write  # Required for creating tags
+  pull-requests: read
+
 jobs:
   version-check:
     runs-on: ubuntu-latest
@@ -43,8 +47,12 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Auto-create Git Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(jq -r '.version' version.json)
           MILESTONE=$(jq -r '.milestone' version.json)


### PR DESCRIPTION
Fixes 403 permission error when creating tags

- Add contents: write permission to workflow
- Use GITHUB_TOKEN explicitly for git operations
- Critical fix for auto-versioning system