### PR TITLE
ci: fix regex syntax error in post-merge automation

### DIFF
--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -46,12 +46,14 @@ jobs:
           # Instead, we'll determine if this is a feature branch based on commit message patterns
           
           # Check if commit message contains version tag pattern (indicates feature branch)
-          if [[ "$COMMIT_MESSAGE" =~ \(v([0-9]+\.[0-9]+\.[0-9]+[^)]*)\) ]]; then
+          VERSION_PATTERN="\\(v([0-9]+\\.[0-9]+\\.[0-9]+[^)]*)\\)"
+          if [[ "$COMMIT_MESSAGE" =~ $VERSION_PATTERN ]]; then
             VERSION="${BASH_REMATCH[1]}"
             
             # Extract feature name from commit message
             # Pattern: "feat: Complete GanttComposer Component (v0.4.0-alpha)"
-            if [[ "$COMMIT_MESSAGE" =~ ^feat:\ (.+)\ \(v[^)]+\) ]]; then
+            FEAT_PATTERN="^feat: (.+) \\(v[^)]+\\)"
+            if [[ "$COMMIT_MESSAGE" =~ $FEAT_PATTERN ]]; then
               FEATURE_TEXT="${BASH_REMATCH[1]}"
               # Convert to feature name format
               FEATURE_NAME="$FEATURE_TEXT"


### PR DESCRIPTION
Critical fix for bash regex syntax error in post-merge workflow.

Problem: syntax error in conditional expression: unexpected token
Solution: Use variable assignment for complex regex patterns with proper escaping

This fixes the immediate workflow failure and allows proper version detection.