### PR TITLE
feat: Add dynamic day width foundation with backward compatibility (v0.7.1)

### DIFF
--- a/src/GanttComponents/Components/TimelineView/TimelineView.razor
+++ b/src/GanttComponents/Components/TimelineView/TimelineView.razor
@@ -20,7 +20,7 @@
             <div class="timeline-header-days">
                 @for (var day = StartDate; day <= EndDate; day = day.AddDays(1))
                 {
-                    <div class="timeline-day" style="width: @(DayWidth)px;">
+                    <div class="timeline-day" style="width: @(EffectiveDayWidth)px;">
                         @day.Day
                     </div>
                 }
@@ -85,10 +85,25 @@
     [Parameter] public EventCallback<int?> OnTaskHovered { get; set; }
     [Parameter] public int? HoveredTaskId { get; set; }
     
+    // Zoom parameters - maintain backward compatibility with current 40px day width
+    [Parameter] public TimelineZoomLevel ZoomLevel { get; set; } = TimelineZoomLevel.MonthDay;
+    [Parameter] public double ZoomFactor { get; set; } = 1.6; // 25px * 1.6 = 40px (maintains current behavior)
+    
     // Timeline configuration
-    private const int DayWidth = 40; // 40px per day (fixed scale)
+    // Legacy constant maintained for reference - replaced by EffectiveDayWidth property
+    private const int LegacyDayWidth = 40; // Was: 40px per day (fixed scale)
     private const int TaskBarHeight = 20;
     private const int TaskBarMargin = 6; // Center task bar in row
+    
+    // Dynamic day width based on zoom level and factor
+    private double EffectiveDayWidth
+    {
+        get
+        {
+            var config = TimelineZoomService.GetConfiguration(ZoomLevel);
+            return config.GetEffectiveDayWidth(ZoomFactor);
+        }
+    }
     
     // Calculated total header height
     private int TotalHeaderHeight => HeaderMonthHeight + HeaderDayHeight;
@@ -130,26 +145,26 @@
         }
         
         var totalDays = (EndDate - StartDate).Days + 1;
-        TotalWidth = totalDays * DayWidth;
+        TotalWidth = (int)(totalDays * EffectiveDayWidth);
         TotalHeight = (Tasks?.Count ?? 0) * RowHeight;
     }
 
     private double DayToPixel(DateTime date)
     {
         var days = (date.Date - StartDate).TotalDays;
-        return days * DayWidth;
+        return days * EffectiveDayWidth;
     }
 
     private double CalculateTaskWidth(GanttTask task)
     {
         var duration = (task.EndDate.Date - task.StartDate.Date).TotalDays + 1;
-        return duration * DayWidth;
+        return duration * EffectiveDayWidth;
     }
 
     private int GetMonthWidth(DateTime month)
     {
         var daysInMonth = DateTime.DaysInMonth(month.Year, month.Month);
-        return daysInMonth * DayWidth;
+        return (int)(daysInMonth * EffectiveDayWidth);
     }
 
     private async Task SelectTask(int taskId)

--- a/tests/GanttComponents.Tests/Unit/Components/TimelineViewZoomTests.cs
+++ b/tests/GanttComponents.Tests/Unit/Components/TimelineViewZoomTests.cs
@@ -1,0 +1,120 @@
+using GanttComponents.Models;
+using GanttComponents.Services;
+using Xunit;
+
+namespace GanttComponents.Tests.Unit.Components;
+
+/// <summary>
+/// Unit tests for TimelineView zoom functionality.
+/// Focus: Backward compatibility and dynamic day width calculation.
+/// </summary>
+public class TimelineViewZoomTests
+{
+    [Fact]
+    public void DefaultZoomParameters_ShouldMaintainBackwardCompatibility()
+    {
+        // Arrange
+        var defaultZoomLevel = TimelineZoomLevel.MonthDay;
+        var defaultZoomFactor = 1.6;
+        var expectedDayWidth = 40.0; // Current legacy behavior
+
+        // Act
+        var config = TimelineZoomService.GetConfiguration(defaultZoomLevel);
+        var actualDayWidth = config.GetEffectiveDayWidth(defaultZoomFactor);
+
+        // Assert
+        Assert.Equal(expectedDayWidth, actualDayWidth, precision: 1);
+    }
+
+    [Fact]
+    public void MonthDayZoomLevel_WithDifferentFactors_ShouldCalculateCorrectly()
+    {
+        // Arrange
+        var zoomLevel = TimelineZoomLevel.MonthDay;
+
+        var testCases = new[]
+        {
+            (factor: 1.0, expected: 25.0),
+            (factor: 1.6, expected: 40.0), // Backward compatibility case
+            (factor: 2.0, expected: 50.0),
+            (factor: 0.5, expected: 12.5)
+        };
+
+        var config = TimelineZoomService.GetConfiguration(zoomLevel);
+
+        // Act & Assert
+        foreach (var (factor, expected) in testCases)
+        {
+            var actual = config.GetEffectiveDayWidth(factor);
+            Assert.Equal(expected, actual, precision: 1);
+        }
+    }
+
+    [Fact]
+    public void AllZoomLevels_ShouldHaveValidConfigurations()
+    {
+        // Arrange
+        var allZoomLevels = Enum.GetValues<TimelineZoomLevel>();
+
+        // Act & Assert
+        foreach (var level in allZoomLevels)
+        {
+            var config = TimelineZoomService.GetConfiguration(level);
+
+            Assert.NotNull(config);
+            Assert.True(config.BaseDayWidth > 0, $"BaseDayWidth for {level} should be positive");
+            Assert.Equal(level, config.Level);
+
+            // Test with default factor
+            var dayWidth = config.GetEffectiveDayWidth(1.0);
+            Assert.True(dayWidth > 0, $"Effective day width for {level} should be positive");
+        }
+    }
+
+    [Theory]
+    [InlineData(TimelineZoomLevel.WeekDay, 1.0, 60.0)]
+    [InlineData(TimelineZoomLevel.MonthDay, 1.0, 25.0)]
+    [InlineData(TimelineZoomLevel.MonthWeek, 1.0, 15.0)]
+    [InlineData(TimelineZoomLevel.QuarterWeek, 1.0, 8.0)]
+    [InlineData(TimelineZoomLevel.QuarterMonth, 1.0, 5.0)]
+    [InlineData(TimelineZoomLevel.YearQuarter, 1.0, 3.0)]
+    public void ZoomLevel_WithBaseFactor_ShouldReturnExpectedDayWidth(
+        TimelineZoomLevel level,
+        double factor,
+        double expectedDayWidth)
+    {
+        // Arrange
+        var config = TimelineZoomService.GetConfiguration(level);
+
+        // Act
+        var actualDayWidth = config.GetEffectiveDayWidth(factor);
+
+        // Assert
+        Assert.Equal(expectedDayWidth, actualDayWidth, precision: 1);
+    }
+
+    [Fact]
+    public void ZoomFactorValidation_ShouldClampToValidRange()
+    {
+        // Arrange
+        var config = TimelineZoomService.GetConfiguration(TimelineZoomLevel.MonthDay);
+        var baseDayWidth = 25.0;
+
+        var testCases = new[]
+        {
+            (inputFactor: 0.1, expectedClamped: 0.5), // Below minimum
+            (inputFactor: 5.0, expectedClamped: 3.0), // Above maximum
+            (inputFactor: 1.5, expectedClamped: 1.5)  // Within range
+        };
+
+        // Act & Assert
+        foreach (var (inputFactor, expectedClamped) in testCases)
+        {
+            var clampedFactor = Math.Max(config.MinZoomFactor, Math.Min(config.MaxZoomFactor, inputFactor));
+            var actualDayWidth = config.GetEffectiveDayWidth(clampedFactor);
+            var expectedDayWidth = baseDayWidth * expectedClamped;
+
+            Assert.Equal(expectedDayWidth, actualDayWidth, precision: 1);
+        }
+    }
+}


### PR DESCRIPTION
## ⭐ Iteration 1.3: Dynamic Day Width Foundation Implementation

### ��� Changes Summary
-  and  parameters added to TimelineView
-  property replaces hardcoded  constant  
- Perfect backward compatibility: MonthDay @ 1.6x = 40px (maintains current behavior)
- All existing APIs preserved: , , 
- Zero UI changes - pure parameter infrastructure

### ��� Technical Implementation
- TimelineView now accepts  (default: MonthDay) and  (default: 1.6)
-  dynamically calculates using 
- All width calculations updated: , , , 
- Type casting added for int return types where needed

### ✅ Backward Compatibility Validation
- Default parameters: MonthDay @ 1.6x = 25px * 1.6 = 40px (exact same as before)
- All existing GanttComposer integration patterns preserved
- Row alignment calculations completely unchanged (vertical scaling unaffected)
- New zoom features only activate when explicitly used (Optional Enhancement pattern)

### ��� Testing Coverage
- 10 new comprehensive unit tests in 
- Tests validate backward compatibility (40px default), parameter combinations, and edge cases
- All 254 tests passing (was 244, added 10 new zoom tests)
- Build validation successful with formatting verified

### ��� Files Changed
- : Added zoom parameters and EffectiveDayWidth
- : Comprehensive test coverage for zoom functionality

### ��� Next Steps
This establishes the parameter foundation for zoom system. Next iteration (1.4) will validate that parameter changes actually affect rendering and complete the width calculation refactoring.

--------

**Part of**: Timeline Zooming System Implementation  
**Strategy**: Lean CI/CD with small, independent iterations  
**Iteration**: 1.3 of 16 planned iterations