### PR TITLE
fix: Correct Codespace port binding and resolve github.dev/pf-signin redirect

### DIFF
--- a/STAKEHOLDER_DEMO_EXPERIENCE_GUIDE.md
+++ b/STAKEHOLDER_DEMO_EXPERIENCE_GUIDE.md
@@ -73,13 +73,15 @@ You'll see output like:
 
 #### 3. **Make Ports Public for Stakeholders**
 1. In VS Code, go to **PORTS** tab (bottom panel)
-2. Find the running port (usually **5234** for HTTP or **7138** for HTTPS)
+2. Find the running ports:
+   - **Port 5234** (HTTP) - Recommended for stakeholder demos
+   - **Port 7138** (HTTPS) - Secure option
 3. **Right-click** → **Port Visibility** → **Public**
-4. **Copy the generated URL** (e.g., `https://scaling-waddle-xxx.github.dev`)
+4. **Copy the generated URL** (e.g., `https://organic-carnival-xxx.github.dev`)
 
 **Important Navigation:**
 - Base URL shows "Not Found" - this is normal
-- **Use HTTP URLs**: Add `/timeline-demo` to the HTTP URL
+- **Add demo path**: Add `/timeline-demo` to the URL
 - **Correct format**: `https://your-codespace-url.github.dev/timeline-demo`
 - Available demo pages:
   - `/timeline-demo` - Timeline zoom features (MAIN DEMO)
@@ -87,16 +89,13 @@ You'll see output like:
   - `/wbs-demo` - Work breakdown structure
 
 **Troubleshooting:**
-- If you see 307 redirects, the app is redirecting HTTP to HTTPS
-- If URL redirects to `github.dev/pf-signin`, restart demo (it will auto-detect Codespace)
-- **Auto-detection**: Demo script automatically uses Codespace profile for external access
-- Use the public HTTPS URL from the PORTS tab
-- Clear browser cache if pages don't load
-
-**Common Issues:**
-- **Authentication redirect**: Restart `./start-demo.sh` - it auto-detects Codespace environment
+- **Authentication redirect** (github.dev/pf-signin): 
+  - Stop the current demo (Ctrl+C)
+  - Restart `./start-demo.sh` - it will auto-detect Codespace
+  - Ensure you're using ports 5234/7138, not 5000/5001
 - **Port not public**: Right-click port in PORTS tab → Port Visibility → Public
 - **Wrong URL**: Use `https://your-url/timeline-demo` not just base URL
+- **Still getting 404**: Check that the application started successfully in terminal
 
 ### **As a Stakeholder (External User):**
 

--- a/start-demo.sh
+++ b/start-demo.sh
@@ -25,8 +25,12 @@ fi
 
 # Set demo environment
 export ASPNETCORE_ENVIRONMENT=Demo
-export ASPNETCORE_URLS="http://0.0.0.0:5000;https://0.0.0.0:5001"
-export ASPNETCORE_HTTPS_PORT=5001
+
+# Only set URLs for local development - let Codespace profile handle its own URLs
+if [ -z "$CODESPACE_NAME" ]; then
+    export ASPNETCORE_URLS="http://localhost:5000;https://localhost:5001"
+    export ASPNETCORE_HTTPS_PORT=5001
+fi
 
 # Display demo features
 echo "🎨 Available Demo Features:"
@@ -49,15 +53,16 @@ echo "🔗 Demo Access Information:"
 if [ -n "$CODESPACES" ]; then
     echo "  📱 For Stakeholder Access:"
     echo "    1. Go to VS Code PORTS tab"
-    echo "    2. Click globe icon next to port 5000"
-    echo "    3. Copy the public URL"
-    echo "    4. Share with stakeholders"
+    echo "    2. Find ports 5234 (HTTP) or 7138 (HTTPS)"
+    echo "    3. Right-click → Port Visibility → Public"
+    echo "    4. Copy the public URL and add /timeline-demo"
+    echo "    5. Example: https://your-codespace-url.github.dev/timeline-demo"
     echo ""
     echo "  🔒 Security: Public URLs allow external access without GitHub login"
 else
     echo "  🏠 Local Access:"
-    echo "    • HTTP:  http://localhost:5000"
-    echo "    • HTTPS: https://localhost:5001"
+    echo "    • HTTP:  http://localhost:5000/timeline-demo"
+    echo "    • HTTPS: https://localhost:5001/timeline-demo"
 fi
 echo ""
 


### PR DESCRIPTION
## ��� Problem Solved

Fixes the github.dev/pf-signin authentication redirect issue that was preventing external stakeholder access to Codespace demos.

## ��� Root Cause

The start-demo.sh script was setting ASPNETCORE_URLS environment variables that overrode the launch profile settings:
- Script set: http://0.0.0.0:5000;https://0.0.0.0:5001 
- Launch profile configured: http://0.0.0.0:5234;https://0.0.0.0:7138
- Result: App bound to wrong ports, causing external access failures

## ✅ Solution

### 1. Environment Variable Fix
- Only set ASPNETCORE_URLS for local development
- Let Codespace profile handle its own port binding (5234/7138)
- Prevents environment variables from overriding launch profile

### 2. Documentation Updates
- Updated demo guide with correct port numbers (5234/7138)
- Added specific troubleshooting for github.dev/pf-signin redirect
- Enhanced port visibility instructions

## ��� Testing

After this fix, the correct workflow should be:
1. Run ./start-demo.sh in Codespace
2. See ports 5234/7138 in PORTS tab (not 5000/5001)
3. Make ports public → get working stakeholder URLs
4. No more authentication redirects

## ��� Files Changed

- start-demo.sh: Fixed environment variable logic
- STAKEHOLDER_DEMO_EXPERIENCE_GUIDE.md: Updated ports and troubleshooting

Resolves the critical issue blocking stakeholder demonstrations.